### PR TITLE
Add missings intents & Update intents names

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -44,7 +44,7 @@ module Discordrb
 
   # All unprivileged intents
   # @see https://discord.com/developers/docs/topics/gateway#privileged-intents
-  UNPRIVILEGED_INTENTS = ALL_INTENTS & ~(INTENTS[:server_members] | INTENTS[:server_presences])
+  UNPRIVILEGED_INTENTS = ALL_INTENTS & ~(INTENTS[:server_members] | INTENTS[:server_presences] | INTENTS[:message_content])
 
   # No intents
   NO_INTENTS = 0

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -30,7 +30,13 @@ module Discordrb
     server_message_typing: 1 << 11,
     direct_messages: 1 << 12,
     direct_message_reactions: 1 << 13,
-    direct_message_typing: 1 << 14
+    direct_message_typing: 1 << 14,
+    message_content: 1 << 15,
+    server_scheduled_events: 1 << 16,
+    auto_moderation_configuration: 1 << 20,
+    auto_moderation_execution: 1 << 21,
+    server_message_polls: 1 << 24,
+    direct_message_polls: 1 << 25
   }.freeze
 
   # All available intents

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -18,8 +18,8 @@ module Discordrb
   INTENTS = {
     servers: 1 << 0,
     server_members: 1 << 1,
-    server_bans: 1 << 2,
-    server_emojis: 1 << 3,
+    server_moderation: 1 << 2,
+    server_emojis_and_stickers: 1 << 3,
     server_integrations: 1 << 4,
     server_webhooks: 1 << 5,
     server_invites: 1 << 6,


### PR DESCRIPTION
# Summary

Add missings intents and renaming of certain intents to match Discord documentation ([List of Intents](https://discord.com/developers/docs/topics/gateway#list-of-intents))

_Intents using `server` instead of `guild` are retained for the time being_

⚠️ **Modification that causes a breaking change for anyone using the old name of one of the modified intents**

---

## Added
- `direct_message_typing`
- `message_content`
- `server_scheduled_events`
- `auto_moderation_configuration`
- `auto_moderation_execution`
- `server_message_polls`
- `direct_message_polls`

## Changed
- `server_bans` to `server_moderation`
- `server_emojis` to `server_emojis_and_stickers`
- Add intent `message_content` to `UNPRIVILEGED_INTENTS` exclusions