### PR TITLE
Upgrade gem websocket-client-simple

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source "https://rubygems.org"
 gemspec name: "discordrb"
 gemspec name: "discordrb-webhooks", development_group: "webhooks"
 
+gem "websocket-client-simple", github: "ruby-jp/websocket-client-simple", tag: "v0.8.0"
+
 group :development do
   gem "rake", "~> 13.0"
   gem "rspec", "~> 3.13"

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ffi", ">= 1.9.24"
   spec.add_dependency "opus-ruby", ">= 1.0.1"
   spec.add_dependency "rest-client", ">= 2.0.0"
-  spec.add_dependency "websocket-client-simple", ">= 0.3.0"
+  spec.add_dependency "websocket-client-simple", ">= 0.8.0"
 
   spec.add_dependency "discordrb-webhooks", "~> 3.5.1"
 end


### PR DESCRIPTION
# Summary

Upgrade gem `websocket-client-simple` with the GitHub source directly, as recommended when installing gems:

```bash
Post-install message from websocket-client-simple:
The development of this gem has moved to https://github.com/ruby-jp/websocket-client-simple.
```

---

## Changed
- Change version constraint from `>= 0.3.0` to `>= 0.8.0`
- Add entry to `Gemfile` to get the gem from GitHub instead of RubyGems