### PR TITLE
Update Discordrb::Attachment

### DIFF
--- a/lib/discordrb/data/attachment.rb
+++ b/lib/discordrb/data/attachment.rb
@@ -4,13 +4,18 @@ module Discordrb
     # Types of attachment's flags mapped to their API value.
     #   List of flags available here: https://discord.com/developers/docs/resources/message#attachment-object-attachment-flags
     FLAGS = {
-      is_remix: 1 << 2,
-      is_spoiler: 1 << 3 # Not officially displayed in the doc, but seems to be the case after several tests.
+      remix: 1 << 2,  # IS_REMIX : this attachment has been edited using the remix feature on mobile
+      spoiler: 1 << 3 #          : this attachment has been set to spoiler mode (not officially listed in doc, but seems to be the case after several tests)
     }.freeze
 
     # @return [Integer] attachment flags combined as a bitfield.
     attr_reader :flags
 
+    # @!method remix?
+    #   @return [true, false] whether this file has flag IS_REMIX.
+    # @!method spoiler?
+    #   @note Unofficial flag
+    #   @return [true, false] whether this file has flag IS_SPOILER.
     FLAGS.each do |name, value|
       define_method(:"#{name}?") do
         (@flags & value).positive?

--- a/lib/discordrb/data/attachment.rb
+++ b/lib/discordrb/data/attachment.rb
@@ -6,6 +6,18 @@ module Discordrb
     # @return [Message] the message this attachment belongs to.
     attr_reader :message
 
+    # @return [String] the attachment's filename.
+    attr_reader :filename
+
+    # @return [String, nil] the attachment's description.
+    attr_reader :description
+
+    # @return [String, nil] the attachment's media type.
+    attr_reader :content_type
+
+    # @return [Integer] the attachment's file size in bytes.
+    attr_reader :size
+
     # @return [String] the CDN URL this attachment can be downloaded at.
     attr_reader :url
 
@@ -13,23 +25,11 @@ module Discordrb
     #   do with CDNs.
     attr_reader :proxy_url
 
-    # @return [String] the attachment's filename.
-    attr_reader :filename
-
-    # @return [Integer] the attachment's file size in bytes.
-    attr_reader :size
-
-    # @return [Integer, nil] the width of an image file, in pixels, or `nil` if the file is not an image.
-    attr_reader :width
-
     # @return [Integer, nil] the height of an image file, in pixels, or `nil` if the file is not an image.
     attr_reader :height
 
-    # @return [String, nil] the attachment's description.
-    attr_reader :description
-
-    # @return [String, nil] the attachment's media type.
-    attr_reader :content_type
+    # @return [Integer, nil] the width of an image file, in pixels, or `nil` if the file is not an image.
+    attr_reader :width
 
     # @return [true, false] whether this attachment is ephemeral.
     attr_reader :ephemeral
@@ -40,18 +40,19 @@ module Discordrb
       @bot = bot
       @message = message
 
-      @id = data["id"].to_i
-      @url = data["url"]
-      @proxy_url = data["proxy_url"]
-      @filename = data["filename"]
+      @id = data["id"].resolve_id
 
+      @filename = data["filename"]
+      @description = data["description"]
+
+      @content_type = data["content_type"]
       @size = data["size"]
 
-      @width = data["width"]
-      @height = data["height"]
+      @url = data["url"]
+      @proxy_url = data["proxy_url"]
 
-      @description = data["description"]
-      @content_type = data["content_type"]
+      @height = data["height"]
+      @width = data["width"]
 
       @ephemeral = data["ephemeral"]
     end

--- a/lib/discordrb/data/attachment.rb
+++ b/lib/discordrb/data/attachment.rb
@@ -65,10 +65,6 @@ module Discordrb
     # @return [String, nil] base64 encoded bytearray representing a sampled waveform (currently for voice messages).
     attr_reader :waveform
 
-    # @return [true, false] whether this attachment is ephemeral.
-    attr_reader :ephemeral
-    alias_method :ephemeral?, :ephemeral
-
     # @!visibility private
     def initialize(data, message, bot)
       @bot = bot
@@ -103,6 +99,11 @@ module Discordrb
     # @return [true, false] whether this file is an audio file.
     def audio?
       !@duration_secs.nil?
+    end
+
+    # @return [true, false] whether this attachment is ephemeral.
+    def ephemeral?
+      @ephemeral
     end
   end
 end


### PR DESCRIPTION
# Summary

Adds attributes missing from the Discord API documentation ([more info](https://discord.com/developers/docs/resources/message#attachment-object-attachment-structure))

Deletion of methods no longer required as a result of this modification

⚠️ **Breaking change following the removal of the `Attachment#ephemeral` method in favor of `Attachment#ephemeral?` only**

---

## Added
- Management of attachments flags
- An `AttachmentAttributes` module to manage these flags
- `Attachment#title`, `Attachment#duration_secs`, `Attachment#waveform`, `Attachment#audio?`, `Attachment#remix?`

## Changed
- Change the behavior of the `Attachment#spoiler?` method to use the flag found above instead of the file name
- Usage of `resolve_id` instead of `to_i` for attachment id

## Removed
- `Attachment#ephemeral`
