### PR TITLE
Bugfix - static emoji considered as animated emoji

### DIFF
--- a/lib/rubycord/bot.rb
+++ b/lib/rubycord/bot.rb
@@ -522,7 +522,7 @@ module Rubycord
             end
           end
         elsif /(?<animated>^a|^${0}):(?<name>\w+):(?<id>\d+)/ =~ mention
-          array_to_return << (emoji(id) || Emoji.new({"animated" => !animated.nil?, "name" => name, "id" => id}, self, nil))
+          array_to_return << (emoji(id) || Emoji.new({"id" => id, "name" => name, "animated" => animated != ""}, self, nil))
         end
       end
       array_to_return


### PR DESCRIPTION
# Summary

When the emoji is not cached, and is instantiated by `Bot#parse_mentions`, it always considers the emoji to be animated, because the regex doesn't return a null value, but an empty string.

---

## Fixed
- Corrects the condition when instantiating an Emoji from `!animated.nil?` to `animated != ""`